### PR TITLE
Fix problem with 'the ' in the middle of journal titles being replaced by earlier commit 

### DIFF
--- a/journal_abbrev.py
+++ b/journal_abbrev.py
@@ -45,6 +45,6 @@ if __name__ == '__main__':
             customize_json = json.load(fin)
         journal_to_abbr.update(customize_json)
 
-    journal_to_abbr = {k.lower(): v for k, v in journal_to_abbr.items()} 
+    journal_to_abbr = {k.lower().replace('the ',''): v for k, v in journal_to_abbr.items()} 
 
     main(journal_to_abbr)


### PR DESCRIPTION
commit 06c7bb6a1878840852cc03f8f1190a0f8e001900 does a good job with journals like 'The Protein Journal', which sometimes is written without the leading 'The'. It creates problems for journals like 'Journal of the American Chemical Society' however. This fix handles both cases, by making the same substitutions in both the dictionary keys and the titles that are matched against them. Note that it will remove all occurrences of 'the ' in the titles, but that is unlikely to cause problems as a lost 'the ' should never(?) result in another existing journal.